### PR TITLE
Enable links in API Doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,11 +162,8 @@ apidoc -f "routes/.*\\.js$" -i ./  -o public/apidoc/ # bug with fish terminal (u
 ```
 
 ### Go to api documentation
-
-```
-open http://localhost:3000/apidoc/ # local
-open https://kleros.io/kleros-store # remote on github page
-```
+Open it locally: http://localhost:3000/apidoc/
+Open it in github pages: https://kleros.io/kleros-store
 
 ### Regenerate api documentation
 


### PR DESCRIPTION
Just making the links to the api docs clickable